### PR TITLE
fixed horizontal scrolling on touch devices for demo 5

### DIFF
--- a/js/horizontal.js
+++ b/js/horizontal.js
@@ -136,9 +136,10 @@
   window.addEventListener("touchmove", ev => {
     let touch = ev.touches[0];
     if (lastClientX && isDown) {
-      state.targetScroll += ev.clientX - lastClientX;
+      let diffX = touch.clientX - lastClientX;
+      state.targetScroll += Math.sign(diffX) * 30;
     }
-    lastClientX = ev.clientX;
+    lastClientX = touch.clientX;
   });
 
   window.addEventListener("wheel", ev => {


### PR DESCRIPTION
fixing issue #1 

changed to get `clientX` attribute from the `ev.touches[0]` as `event` does not have that attribute
apply wheel scrolling formula to calculate `state.targetScroll`